### PR TITLE
Nether portal lit on the other side

### DIFF
--- a/src/NetherPortalScanner.cpp
+++ b/src/NetherPortalScanner.cpp
@@ -264,7 +264,7 @@ void cNetherPortalScanner::BuildNetherPortal(Vector3i a_Location, Direction a_Di
 	}
 
 	// Fill the frame (place a fire in the bottom)
-	m_World.SetBlock(x + 1, y + 1, z + 1, E_BLOCK_FIRE, 0);
+	m_World.PlaceBlock(Vector3<int>(x + 1, y + 1, z + 1), E_BLOCK_FIRE, 0);
 }
 
 


### PR DESCRIPTION
The nether portal should now be lit when you get out in the other dimension.

Fixed Issue  #5007